### PR TITLE
fix missing turn_off_old_tag method

### DIFF
--- a/ladybug_tools/sverchok.py
+++ b/ladybug_tools/sverchok.py
@@ -484,3 +484,9 @@ def schedule_solution(component, milliseconds):
     return
     doc = component.OnPingDocument()
     doc.ScheduleSolution(milliseconds)
+
+
+# Empty method that LB requires.
+# Method itself seems to be Rhino specific
+# and doesn't require an implementation.
+def turn_off_old_tag(component): ...


### PR DESCRIPTION
Since https://github.com/ladybug-tools/ladybug-grasshopper/commit/45b43719561f5a68985cd8be3fe67ebc1041b7d7 Many LB nodes are trying to import and call `turn_off_old_tag` method with `Ghenv().component` as an argument

And if it's not implemented we end up with the exception below: cannot import name 'turn_off_old_tag' from 'ladybug_tools.sverchok' (\addons\ladybug_tools\sverchok.py)

The method itself seems to Rhino specific thing needed to disable some obsolete components Rhino implementation of this method for a reference: https://github.com/ladybug-tools/ladybug-rhino/blob/master/ladybug_rhino/grasshopper.py But since our component in helper.ghenv.Component is None either way, I guess we can just skip it.

Example issue - https://community.osarch.org/discussion/comment/20571/#Comment_20571