### PR TITLE
ci-ladybug-blender-build.yml - remove repository requirement

### DIFF
--- a/.github/workflows/ci-ladybug-blender-build.yml
+++ b/.github/workflows/ci-ladybug-blender-build.yml
@@ -12,8 +12,6 @@ env:
 jobs:
   activate:
     runs-on: ubuntu-latest
-    if: |
-      github.repository == 'Andrej730/ladybug-blender'
     steps:
     - name: Set env
       run: echo ok go


### PR DESCRIPTION
forgot to remove it after tests, therefore daily builds wasn't available on the main repo